### PR TITLE
Link parsing breaks when <atom:link> is present before <link> in a feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ feeder:stream(Xml, Opts) -> Result
 ```erlang
 feeder_feeds:get(Key, Feed) -> Value
 ```
-- `Key = author | id | image | language | link | subtitle | summary | title | updated`
+- `Key = author | id | image | language | link | subtitle | summary | title | updated | url`
 - `Feed = feed()`
 - `Value = binary() | undefined`
 

--- a/src/feeder.erl
+++ b/src/feeder.erl
@@ -52,6 +52,8 @@ feed(F, image, State) ->
   update(F, #feed.image, State#state.chars);
 feed(F, url, State) when State#state.image =:= true ->
   update(F, #feed.image, State#state.chars);
+feed(F, url, State) ->
+  update(F, #feed.url, State#state.chars);
 feed(F, language, State) ->
   update(F, #feed.language, State#state.chars);
 feed(F, link, State) ->
@@ -129,6 +131,8 @@ attribute(feed, State, link, Attrs) ->
   feed(State#state.feed, link, State#state{chars=href(Attrs)});
 attribute(feed, State, image, Attrs) ->
   feed(State#state.feed, image, State#state{chars=href(Attrs)});
+attribute(feed, State, url, Attrs) ->
+  feed(State#state.feed, url, State#state{chars=href(Attrs)});
 attribute(feed, State, _, _) ->
   State#state.feed;
 attribute(entry, State, link, Attrs) ->
@@ -189,6 +193,7 @@ start_element(E, Attrs, State) when ?IS_ENTRY ->
 
 %% First pass
 
+qname({"atom", "link"}) -> url;
 qname({_, "author"}) -> author;
 qname({_, "channel"}) -> feed;
 qname({_, "contributor"}) -> author;
@@ -265,27 +270,28 @@ trim_test() ->
   ?assertMatch(<<"hello">>, trim(" hello ")),
   ok.
 
-q([{Wanted, Names}|T]) ->
-  F = fun (Name) -> ?assertMatch(Wanted, qname({"", Name})) end,
-  lists:map(F, Names),
+q([{Wanted, QualifiedNames}|T]) ->
+  F = fun (QualifiedName) -> ?assertMatch(Wanted, qname(QualifiedName)) end,
+  lists:map(F, QualifiedNames),
   q(T);
 q([]) ->
   ok.
 qname_test() -> q([
-  {author, ["author"]},
-  {duration, ["duration"]},
-  {enclosure, ["enclosure"]},
-  {entry, ["entry", "item"]},
-  {feed, ["feed", "channel"]},
-  {id, ["id", "guid"]},
-  {image, ["image"]},
-  {language, ["language"]},
-  {link, ["link"]},
-  {name, ["name"]},
-  {subtitle, ["subtitle"]},
-  {summary, ["summary", "description"]},
-  {title, ["title"]},
-  {undefined, ["wtf", "", "!"]},
-  {updated, ["updated", "pubDate"]}
+  {author, [{"", "author"}]},
+  {duration, [{"", "duration"}]},
+  {enclosure, [{"", "enclosure"}]},
+  {entry, [{"", "entry"}, {"", "item"}]},
+  {feed, [{"", "feed"}, {"", "channel"}]},
+  {id, [{"", "id"}, {"", "guid"}]},
+  {image, [{"", "image"}]},
+  {language, [{"", "language"}]},
+  {link, [{"", "link"}]},
+  {name, [{"", "name"}]},
+  {subtitle, [{"", "subtitle"}]},
+  {summary, [{"", "summary"}, {"", "description"}]},
+  {title, [{"", "title"}]},
+  {undefined, [{"", "wtf"}, {"", ""}, {"", "!"}]},
+  {updated, [{"", "updated"}, {"", "pubDate"}]},
+  {url, [{"atom", "link"}]}
 ]).
 -endif.

--- a/src/feeder_feeds.erl
+++ b/src/feeder_feeds.erl
@@ -21,4 +21,6 @@ get(summary, F) ->
 get(title, F) ->
   F#feed.title;
 get(updated, F) ->
-  F#feed.updated.
+  F#feed.updated;
+get(url, F) ->
+  F#feed.url.

--- a/src/feeder_records.hrl
+++ b/src/feeder_records.hrl
@@ -13,7 +13,8 @@
   subtitle :: undefined | binary(),
   summary :: undefined | binary(),
   title :: undefined | binary(),
-  updated :: undefined | binary()
+  updated :: undefined | binary(),
+  url :: undefined | binary()
 }).
 
 -record(entry, {

--- a/test/feeder_SUITE_data/atom.erl
+++ b/test/feeder_SUITE_data/atom.erl
@@ -12,7 +12,8 @@ wanted() -> {{
   undefined,
   undefined,
   <<"Example Feed">>,
-  <<"Sun, 18 May 2014 16:13:31 GMT">>}, [
+  <<"Sun, 18 May 2014 16:13:31 GMT">>,
+  <<"http://example.org/feed/">>}, [
 {
   entry,
   undefined,

--- a/test/feeder_SUITE_data/atom.xml
+++ b/test/feeder_SUITE_data/atom.xml
@@ -2,6 +2,7 @@
 <feed xmlns="http://www.w3.org/2005/Atom">
 
     <title>Example Feed</title>
+    <atom:link href="http://example.org/feed/" rel="self" type="application/rss+xml" />
     <link href="http://example.org/"/>
     <updated>Sun, 18 May 2014 16:13:31 GMT</updated>
     <author>

--- a/test/feeder_SUITE_data/author.erl
+++ b/test/feeder_SUITE_data/author.erl
@@ -12,6 +12,7 @@ wanted() -> {{
   undefined,
   undefined,
   undefined,
+  undefined,
   undefined}, [
 {
   entry,

--- a/test/feeder_SUITE_data/itunes.erl
+++ b/test/feeder_SUITE_data/itunes.erl
@@ -12,6 +12,7 @@ wanted() -> {{
   <<"A show about everything">>,
   <<"All About Everything is a show about everything. Each week we dive into any subject known to man and talk about it as much as we can. Look for our Podcast in the iTunes Store">>,
   <<"All About Everything">>,
+  undefined,
   undefined}, [
 {
   entry,

--- a/test/feeder_SUITE_data/rss.erl
+++ b/test/feeder_SUITE_data/rss.erl
@@ -12,7 +12,8 @@ wanted() -> {{
   undefined,
   <<"Liftoff to Space Exploration.">>,
   <<"Liftoff News">>,
-  <<"Tue, 10 Jun 2003 04:00:00 GMT">>}, [
+  <<"Tue, 10 Jun 2003 04:00:00 GMT">>,
+  <<"http://liftoff.msfc.nasa.gov/">>}, [
 {
   entry,
   undefined,


### PR DESCRIPTION
I stumbled upon a feed having an `<atom:link />` before the `<link />` tag. I'd love to help fix this but am new to Erlang (coming from Elixir) so help would be much appreciated.

//edit: I also added an example to the test data so we have a failing test to start with 😁 